### PR TITLE
Only trigger isDeopt once

### DIFF
--- a/src/codegen/ast_interpreter.cpp
+++ b/src/codegen/ast_interpreter.cpp
@@ -1819,8 +1819,10 @@ Box* astInterpretFunctionEval(CLFunction* clfunc, Box* globals, Box* boxedLocals
     return v ? v : None;
 }
 
-Box* astInterpretDeopt(CLFunction* clfunc, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
-                       FrameStackState frame_state) {
+static Box* astInterpretDeoptInner(CLFunction* clfunc, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
+                                   FrameStackState frame_state) __attribute__((noinline));
+static Box* astInterpretDeoptInner(CLFunction* clfunc, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
+                                   FrameStackState frame_state) {
     assert(clfunc);
     assert(enclosing_stmt);
     assert(frame_state.locals);
@@ -1908,6 +1910,11 @@ Box* astInterpretDeopt(CLFunction* clfunc, AST_expr* after_expr, AST_stmt* enclo
 
     Box* v = ASTInterpreter::execute(interpreter, start_block, starting_statement);
     return v ? v : None;
+}
+
+Box* astInterpretDeopt(CLFunction* clfunc, AST_expr* after_expr, AST_stmt* enclosing_stmt, Box* expr_val,
+                       FrameStackState frame_state) {
+    return astInterpretDeoptInner(clfunc, after_expr, enclosing_stmt, expr_val, frame_state);
 }
 
 extern "C" void printExprHelper(Box* obj) {

--- a/src/codegen/unwinding.cpp
+++ b/src/codegen/unwinding.cpp
@@ -510,6 +510,7 @@ public:
         bool rtn = false;
 
         if (isDeopt(ip)) {
+            assert(!skip_next_pythonlike_frame);
             skip_next_pythonlike_frame = true;
         } else if (frameIsPythonFrame(ip, bp, cursor, frame_iter)) {
             if (!skip_next_pythonlike_frame)


### PR DESCRIPTION
By moving the deopt logic into an inner frame.  I think we trigger
the isDeopt() block twice since there's a destructor that has to
get run.
